### PR TITLE
phpmyadminも立ち上がるようにしました。

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,6 @@
 {
     "name": "PracticeLaravel",
-<<<<<<< HEAD
-    "dockerComposeFile":"../dockercompose.yml",
-    "service": "workspace",
-    "workspaceFolder": "/"
-=======
     "dockerComposeFile":"dockercompose.yml",
     "service": "workspace",
     "workspaceFolder": "/application"
->>>>>>> dbe48a1 (devcontainer setting)
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,0 @@
-{
-    "name": "PracticeLaravel",
-    "dockerComposeFile":"dockercompose.yml",
-    "service": "app",
-    "workspaceFolder": "/application"
-}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "PracticeLaravel",
+<<<<<<< HEAD
+    "dockerComposeFile":"../dockercompose.yml",
+    "service": "workspace",
+    "workspaceFolder": "/"
+=======
+    "dockerComposeFile":"dockercompose.yml",
+    "service": "workspace",
+    "workspaceFolder": "/application"
+>>>>>>> dbe48a1 (devcontainer setting)
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "PracticeLaravel",
     "dockerComposeFile":"dockercompose.yml",
-    "service": "workspace",
+    "service": "app",
     "workspaceFolder": "/application"
 }

--- a/README
+++ b/README
@@ -1,4 +1,5 @@
 さくっとPHPを試したいときに使う。
 
+docker compose build
 docker compose up -d
-Laraveをインストールしてある。
+Larave, phpmyadmin をインストールしてある。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   php-server:
     platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     depends_on:
       - mysql-server
       - mailpit
+      - phpmyadmin
     volumes:
       - ./:/application:cached
       - ./docker/php.ini:/usr/local/etc/php/php.ini
@@ -13,14 +14,30 @@ services:
   mysql-server:
     platform: linux/amd64
     image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password
+    restart: always
     ports:
       - "43306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=secret
       - MYSQL_DATABASE=php-db
     volumes:
-      - db-data:/var/lib/mysql:cached
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=mysql-server
+      - PMA_USER=root
+      - PMA_PASSWORD=secret
 
   nginx:
     platform: linux/amd64
@@ -38,7 +55,6 @@ services:
     image: axllent/mailpit
     ports:
       - "8025:8025"
-      - "1025:1025"
 
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     build: ./docker
     image: php
     depends_on:
-      - mysql
+      - mysql-server
       - mailpit
     volumes:
       - ./:/application:cached
       - ./docker/php.ini:/usr/local/etc/php/php.ini
 
-  mysql:
+  mysql-server:
     platform: linux/amd64
     image: mysql:8
     command: --default-authentication-plugin=mysql_native_password

--- a/laravel-app/.env.example
+++ b/laravel-app/.env.example
@@ -9,7 +9,7 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=mysql
-DB_HOST=mysql
+DB_HOST=mysql-server
 DB_PORT=3306
 DB_DATABASE=laravel
 DB_USERNAME=root


### PR DESCRIPTION
# やったこと
phpmyadminも立ち上がるようにしました。

以下のコマンドを実行してください。
docker compose build
docker compose up -d

VSコードのポートの部分に8080と書いてあるところがphpmyadminなので、
127.0.0.1:8080にアクセスすると入れます。
![image](https://github.com/kanal227/php-practice-docker-laravel/assets/20674685/1e00c3ab-1d6f-455e-a89a-999a8c8b61e7)

これを使ってLaravelの演習を進めてください。

# やってほしいこと
このPRをmainにマージして、codespaceを再度作り直してください。
　